### PR TITLE
chore: remove useless getInitialProps to enable Automatic Static Optimization

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -26,15 +26,7 @@ Router.events.on("routeChangeError", () => {
 });
 
 export default class MyApp extends App {
-  static async getInitialProps({ Component, router, ctx }) {
-    let pageProps = {};
-
-    if (Component.getInitialProps) {
-      pageProps = await Component.getInitialProps(ctx);
-    }
-
-    return { pageProps };
-  }
+  
   render() {
     const { Component, pageProps } = this.props;
 


### PR DESCRIPTION
If you use getInitialProps, it will disable the Automatic Static Optimization provided by nextjs.
In addition, your site is static and doesn't have to fetch data as props on the server side.
If you have some requirements to fetch data in the future, you can use getServerSIdeProps or getStaticProps.

ref: https://nextjs.org/docs/advanced-features/custom-app
ref: https://nextjs.org/docs/advanced-features/automatic-static-optimization